### PR TITLE
Ignore commit status in CI

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,7 +39,7 @@ jobs:
           git commit -m 'Update README.md' || true
 
       - name: Push branch main back to origin
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         run: |
           git push origin main
 
@@ -77,6 +77,6 @@ jobs:
 
 
       - name: Push branch pages back to origin
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         run: |
           git push origin pages

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -e
           git add README.md
-          git commit -m 'Update README.md'
+          git commit -m 'Update README.md' || true
 
       - name: Push branch main back to origin
         if: ${{ github.event_name == 'push' }}
@@ -73,7 +73,7 @@ jobs:
           mv ../api .
           echo "yaksplained.org" > CNAME
           git add api CNAME
-          git commit -m 'Generate new pages'
+          git commit -m 'Generate new pages' || true
 
 
       - name: Push branch pages back to origin


### PR DESCRIPTION
For some reason, committing nothing makes git commit exit with a non-zero exit code, which in turn makes the action fail. This is an issue for a variety of commits that don't change anything regarded by the action.

(PR because I don't want to needlessly fuck around with this)